### PR TITLE
Strain optional

### DIFF
--- a/modules/ReferenceTrack/Controller.pm
+++ b/modules/ReferenceTrack/Controller.pm
@@ -43,7 +43,7 @@ sub run
 {
   my($self) = @_;
 
-  if((defined($self->creation_details) )&& @{$self->creation_details} ==3)
+  if((defined($self->creation_details) )&& (@{$self->creation_details}==2 || @{$self->creation_details}==3))
   {
     $self->_create_reference_repository();
   }

--- a/modules/ReferenceTrack/Repositories.pm
+++ b/modules/ReferenceTrack/Repositories.pm
@@ -22,9 +22,10 @@ has '_dbh'                         => ( is => 'rw', required   => 1 );
 
 sub _find_all_by_name_result_set
 {
-  my ($self,$query) = @_;
+  my ($self,$query,$exact_match) = @_;
   return if Scalar::Util::tainted($query); 
-  $self->_dbh->resultset('Repositories')->search({ name => { -like => '%'.$query.'%' } });
+  my $search_term = $exact_match ? $query : '%'.$query.'%';
+  $self->_dbh->resultset('Repositories')->search({ name => { -like => $search_term } });
 }
 
 sub find_all_by_name
@@ -39,6 +40,13 @@ sub find_by_name
    my ($self,$query) = @_;
    $self->_find_all_by_name_result_set($query)->first;
 }
+
+sub find_by_full_name
+{
+   my ($self,$query) = @_;
+   $self->_find_all_by_name_result_set($query, 1)->first;
+}
+
 no Moose;
 __PACKAGE__->meta->make_immutable;
 1;

--- a/modules/ReferenceTrack/Repository.pm
+++ b/modules/ReferenceTrack/Repository.pm
@@ -35,7 +35,7 @@ sub name_exists
   my ($self) = @_;
   my $repository = ReferenceTrack::Repositories->new(_dbh     => $self->_dbh);
   $repository->find_by_name($self->name);
-  return 1 if(defined($repository->find_by_name($self->name) ));
+  return 1 if(defined($repository->find_by_full_name($self->name) ));
 
   return 0;
 }

--- a/modules/ReferenceTrack/Repository/Name.pm
+++ b/modules/ReferenceTrack/Repository/Name.pm
@@ -21,7 +21,7 @@ use ReferenceTrack::Repository::Types;
 
 has 'genus'      => ( is => 'ro', isa => 'ReferenceTrack::Repository::Name::Genus',      required => 1, coerce => 1 );
 has 'subspecies' => ( is => 'ro', isa => 'ReferenceTrack::Repository::Name::Subspecies', required => 1, coerce => 1 );
-has 'strain'     => ( is => 'ro', isa => 'ReferenceTrack::Repository::Name::Strain',     required => 1);
+has 'strain'     => ( is => 'ro', isa => 'Maybe[ReferenceTrack::Repository::Name::Strain]',     required => 1);
 has 'short_name' => ( is => 'ro', isa => 'ReferenceTrack::Repository::Name::ShortName',  required => 1 );
 
 
@@ -31,14 +31,17 @@ has 'human_readable_name' => ( is => 'ro', isa => 'Str', lazy => 1, builder => '
 sub _build_repository_name
 {
   my($self) = @_;
-  my $base_repo_name = join("_", ($self->genus, $self->subspecies, $self->strain));
+  my $base_repo_name = join("_", ($self->genus, $self->subspecies));
+  $base_repo_name = join("_", ($base_repo_name, $self->strain)) if defined($self->strain);
   join('.', ($base_repo_name, 'git'));
 }
 
 sub _build_human_readable_name
 {
   my($self) = @_;
-  join(" ", ($self->genus, $self->subspecies, $self->strain));
+  my $name = join(" ", ($self->genus, $self->subspecies));
+  $name = join(" ", ($name, $self->strain)) if defined $self->strain;
+  return $name;
 }
 
 

--- a/modules/ReferenceTrack/Repository/Types.pm
+++ b/modules/ReferenceTrack/Repository/Types.pm
@@ -17,7 +17,7 @@ coerce 'ReferenceTrack::Repository::Name::Subspecies',
   via { lc($_) };
   
 subtype 'ReferenceTrack::Repository::Name::Strain',
-  as 'Str',
+  as 'Maybe[Str]',
   where { ReferenceTrack::Repository::Validate::Name->new()->is_strain_valid($_) };
   
 subtype 'ReferenceTrack::Repository::Version::Number',

--- a/modules/ReferenceTrack/Repository/Validate/Name.pm
+++ b/modules/ReferenceTrack/Repository/Validate/Name.pm
@@ -35,7 +35,7 @@ sub is_subspecies_valid
 sub is_strain_valid
 {
   my($self, $input_string) = @_;
-  return 0 if( $input_string =~ /[\W]/ || length($input_string) <= 1);
+  return 0 if(defined($input_string) && ($input_string =~ /[\W]/ || length($input_string) <= 1));
   
   return 1;
 }

--- a/reference_track_management.pl
+++ b/reference_track_management.pl
@@ -32,7 +32,7 @@ my ($database, @repository_details, $public_release_repository,@creation_details
 GetOptions ('database|d=s'    => \$database,
             'a|add=s{2}'         => \@repository_details,
             'p|public_release=s'   => \$public_release_repository,
-            'c|create=s{3}'        => \@creation_details,
+            'c|create=s{2,3}'      => \@creation_details,
             's|starting_version=s' => \$starting_version,
             'n|short_name=s'       => \$short_name,
             'm|major_release=s'    => \$major_release,
@@ -41,7 +41,7 @@ GetOptions ('database|d=s'    => \$database,
             
 );
 
-((@repository_details == 2) || defined $upload_to_ftp_site ||$public_release_repository || $major_release || $minor_release || (@creation_details == 3 && $short_name))or die <<USAGE;
+((@repository_details == 2) || defined $upload_to_ftp_site ||$public_release_repository || $major_release || $minor_release || ((@creation_details == 2 || @creation_details == 3) && $short_name))or die <<USAGE;
 Usage: $0 [options]
 Query the reference tracking system
 

--- a/t/ReferenceTrack/Repositories.t
+++ b/t/ReferenceTrack/Repositories.t
@@ -18,7 +18,8 @@ $dbh->resultset('Repositories')->create({ name => "existing repo", location => '
 $dbh->resultset('Repositories')->create({ name => "another repo",  location => 'some_location.git', short_name => "ABC3"   });
 
 ok my $repository = ReferenceTrack::Repositories->new( _dbh     => $dbh), 'initialise repositories';
-is 'some_location.git' , $repository->find_by_name('repo')->location, 'return a single row';
+is 'some_location.git' , $repository->find_by_name('repo')->location, 'return a single row (find_by_name)';
+is 'some_location.git' , $repository->find_by_full_name('existing repo')->location, 'return a single row (find_by_full_name)';
 
 is 2, @{$repository->find_all_by_name('repo')}, 'get all matching rows';
 is 'some_location.git', $repository->find_all_by_name('repo')->[0]->location,'check that the rows are actually returned for first element';


### PR DESCRIPTION
Added code to deal with cases where references don't have a strain name.

When creating a repo, the strain name is optional. The strain name isn't part of the name of the stored repo unless the strain name is defined. 

Also, the code checks against the full name of the repo to see if it already exists in the database.
